### PR TITLE
Fix spacing for 3rd party login button

### DIFF
--- a/login-buttons-single.html
+++ b/login-buttons-single.html
@@ -1,5 +1,5 @@
 <template name="_loginButtonsLoggedOutSingleLoginButton">
-	<div class="ui fluid input">
+	<div class="ui divided list">
 		<div class="ui labeled icon fluid button login-button {{#unless configured}}configure-button{{/unless}} {{#if configured}}primary{{/if}}" id="login-buttons-{{name}}">
 			<div class="ui icon" id="login-buttons-image-{{name}}" style="background-repeat: no-repeat; background-position: 50% 50%;"></div>
 			{{#if configured}}


### PR DESCRIPTION
Changing to a 'ui divided list' fixes the spacing for 3rd party login buttons, and it works for multiple services.
